### PR TITLE
Add comment to manifest.json

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -22,6 +22,7 @@
     }
   ],
   "devtools_page": "devtools.html",
+  "__COMMENT__": "Remove the 'devtools_page' line to avoid the permissions warning 'Read and change all your data on all websites' on install.",
   "web_accessible_resources": [
     {
       "resources": ["content.styles.css", "icon-128.png", "icon-34.png"],


### PR DESCRIPTION
If you include `devtools_page` in your extension manifest, your extension will show the following permissions warning on install: 
- Read and change all your data on all websites

I wasted quite some time trying to figure out why I was getting this warning—it's hardly obvious that the `devtools_page` thing would trigger it.

I suggest adding a comment about this, or else removing the line completely.